### PR TITLE
Flexi-grid Path Computation YANG

### DIFF
--- a/ietf-flexi-grid-path-computation.tree
+++ b/ietf-flexi-grid-path-computation.tree
@@ -1,0 +1,147 @@
+module: ietf-flexi-grid-path-computation
+
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request:
+    +-- fec-type?                identityref
+    +-- termination-type?        identityref
+    +-- bit-stuffing?            boolean
+    +-- wavelength-assignment?   identityref
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-in-segment
+            /tepc:label-restrictions/tepc:label-restriction:
+    +-- grid-type?    identityref
+    +-- priority?     uint8
+    +-- flexi-grid
+       +-- slot-width-granularity?   identityref
+       +-- min-slot-width-factor?    uint16
+       +-- max-slot-width-factor?    uint16
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-out-segment
+            /tepc:label-restrictions/tepc:label-restriction:
+    +-- grid-type?    identityref
+    +-- priority?     uint8
+    +-- flexi-grid
+       +-- slot-width-granularity?   identityref
+       +-- min-slot-width-factor?    uint16
+       +-- max-slot-width-factor?    uint16
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:optimizations/tepc:algorithm
+            /tepc:metric/tepc:optimization-metric
+            /tepc:explicit-route-exclude-objects
+            /tepc:route-object-exclude-object/tepc:type/tepc:label
+            /tepc:label-hop/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- (single-or-super-channel)?
+          +--:(single)
+          |  +-- flexi-n?              l0-types:flexi-n
+          |  +-- flexi-m?              l0-types:flexi-m
+          +--:(super)
+             +-- subcarrier-flexi-n* [flexi-n]
+                +-- flexi-n    l0-types:flexi-n
+                +-- flexi-m?   l0-types:flexi-m
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:optimizations/tepc:algorithm
+            /tepc:metric/tepc:optimization-metric
+            /tepc:explicit-route-include-objects
+            /tepc:route-object-include-object/tepc:type/tepc:label
+            /tepc:label-hop/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- (single-or-super-channel)?
+          +--:(single)
+          |  +-- flexi-n?              l0-types:flexi-n
+          |  +-- flexi-m?              l0-types:flexi-m
+          +--:(super)
+             +-- subcarrier-flexi-n* [flexi-n]
+                +-- flexi-n    l0-types:flexi-n
+                +-- flexi-m?   l0-types:flexi-m
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:explicit-route-objects-always
+            /tepc:route-object-exclude-always/tepc:type/tepc:label
+            /tepc:label-hop/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- (single-or-super-channel)?
+          +--:(single)
+          |  +-- flexi-n?              l0-types:flexi-n
+          |  +-- flexi-m?              l0-types:flexi-m
+          +--:(super)
+             +-- subcarrier-flexi-n* [flexi-n]
+                +-- flexi-n    l0-types:flexi-n
+                +-- flexi-m?   l0-types:flexi-m
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:explicit-route-objects-always
+            /tepc:route-object-include-exclude/tepc:type/tepc:label
+            /tepc:label-hop/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- (single-or-super-channel)?
+          +--:(single)
+          |  +-- flexi-n?              l0-types:flexi-n
+          |  +-- flexi-m?              l0-types:flexi-m
+          +--:(super)
+             +-- subcarrier-flexi-n* [flexi-n]
+                +-- flexi-n    l0-types:flexi-n
+                +-- flexi-m?   l0-types:flexi-m
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-in-segment
+            /tepc:label-restrictions/tepc:label-restriction
+            /tepc:label-start/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- flexi-n?   l0-types:flexi-n
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-in-segment
+            /tepc:label-restrictions/tepc:label-restriction
+            /tepc:label-end/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- flexi-n?   l0-types:flexi-n
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-in-segment
+            /tepc:label-restrictions/tepc:label-restriction
+            /tepc:label-step/tepc:technology:
+    +--:(flexi-grid)
+       +-- flexi-grid-channel-spacing?   identityref
+       +-- flexi-n-step?                 uint8
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-out-segment
+            /tepc:label-restrictions/tepc:label-restriction
+            /tepc:label-start/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- flexi-n?   l0-types:flexi-n
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-out-segment
+            /tepc:label-restrictions/tepc:label-restriction
+            /tepc:label-end/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +-- flexi-n?   l0-types:flexi-n
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:path-request/tepc:path-out-segment
+            /tepc:label-restrictions/tepc:label-restriction
+            /tepc:label-step/tepc:technology:
+    +--:(flexi-grid)
+       +-- flexi-grid-channel-spacing?   identityref
+       +-- flexi-n-step?                 uint8
+  augment /te:tunnels-path-compute/te:input/te:path-compute-info
+            /tepc:synchronization/tepc:exclude-objects/tepc:excludes
+            /tepc:type/tepc:label/tepc:label-hop/tepc:te-label
+            /tepc:technology:
+    +--:(flexi-grid)
+       +-- (single-or-super-channel)?
+          +--:(single)
+          |  +-- flexi-n?              l0-types:flexi-n
+          |  +-- flexi-m?              l0-types:flexi-m
+          +--:(super)
+             +-- subcarrier-flexi-n* [flexi-n]
+                +-- flexi-n    l0-types:flexi-n
+                +-- flexi-m?   l0-types:flexi-m
+  augment /te:tunnels-path-compute/te:output/te:path-compute-result
+            /tepc:response/tepc:computed-paths-properties
+            /tepc:computed-path-properties/tepc:path-properties
+            /tepc:path-route-objects/tepc:path-route-object/tepc:type
+            /tepc:label/tepc:label-hop/tepc:te-label/tepc:technology:
+    +--:(flexi-grid)
+       +--ro (single-or-super-channel)?
+          +--:(single)
+          |  +--ro flexi-n?              l0-types:flexi-n
+          |  +--ro flexi-m?              l0-types:flexi-m
+          +--:(super)
+             +--ro subcarrier-flexi-n* [flexi-n]
+                +--ro flexi-n    l0-types:flexi-n
+                +--ro flexi-m?   l0-types:flexi-m

--- a/ietf-flexi-grid-path-computation.yang
+++ b/ietf-flexi-grid-path-computation.yang
@@ -1,0 +1,266 @@
+module ietf-flexi-grid-path-computation {
+  yang-version 1.1;
+  namespace
+    "urn:ietf:params:xml:ns:yang:ietf-flexi-grid-path-computation";
+  prefix "flexg-pc";
+
+  import ietf-te-path-computation {
+    prefix "tepc";
+    revision-date "2021-09-06";
+    reference 
+    "I-D.ietf-teas-yang-path-computation-14: Yang model
+    for requesting Path Computation.";
+  }
+
+  import ietf-te {
+    prefix "te";
+    revision-date "2021-02-20";
+    reference
+      "I-D.ietf-teas-yang-te-19: A YANG Data Model for Traffic
+      Engineering Tunnels and Interfaces. ";
+  }
+
+  import ietf-layer0-types {
+    prefix "l0-types";
+  }
+
+  import ietf-layer0-types-ext {
+    prefix "l0-types-ext";
+  }
+
+  organization
+    "IETF CCAMP Working Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/ccamp/>
+     WG List:  <mailto:ccamp@ietf.org>
+
+     Editor:   Aihua Guo
+               <mailto:aihuaguo.ietf@gmail.com>
+
+     Editor:   Italo Busi
+               <mailto:italo.busi@huawei.com>
+
+     Editor:   Sergio Belotti
+               <mailto:sergio.belotti@nokia.com>";
+
+  description
+    "This module defines a model for requesting
+    Flexi-grid Path Computation.
+
+    The model fully conforms to the Network Management 
+    Datastore Architecture (NMDA).
+    
+    Copyright (c) 2021 IETF Trust and the persons
+    identified as authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (https://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC XXXX; see
+    the RFC itself for full legal notices.";
+
+  revision "2021-10-15" {
+    description
+      "Initial version.";
+    reference
+      "RFC XXXX: YANG Model for OTN and Optical Path Computation";
+    // RFC Ed.: replace XXXX with actual RFC number, update date 
+    // information and remove this note
+  }
+
+ /*
+  * Data nodes
+  */
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request" {
+    description
+       "Augment with additional constraints flexi-grid
+        media channel.";
+    uses l0-types-ext:l0-tunnel-attributes;
+    uses l0-types-ext:l0-path-constraints;
+  }
+
+  /*
+   * Augment TE label range information
+   */
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-in-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction" {
+    description
+      "Augment TE label range information for the ingress segment
+      of the requested path.";
+    uses l0-types:flexi-grid-label-range-info;
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-out-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction" {
+    description
+      "Augment TE label range information for the egress segment
+      of the requested path.";
+    uses l0-types:flexi-grid-label-range-info;
+  }
+
+  /*
+   * Augment TE label.
+   */
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:optimizations/tepc:algorithm/"
+        + "tepc:metric/tepc:optimization-metric/"
+        + "tepc:explicit-route-exclude-objects/"
+        + "tepc:route-object-exclude-object/tepc:type/tepc:label/"
+        + "tepc:label-hop/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label hop for the optimization of the explicit
+      route objects excluded by the path computation of the requested
+      path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-hop;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:optimizations/tepc:algorithm/"
+        + "tepc:metric/tepc:optimization-metric/"
+        + "tepc:explicit-route-include-objects/"
+        + "tepc:route-object-include-object/tepc:type/tepc:label/"
+        + "tepc:label-hop/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label hop for the optimization of the explicit
+      route objects included by the path computation of the requested
+      path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-hop;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:explicit-route-objects-always/"
+        + "tepc:route-object-exclude-always/tepc:type/tepc:label/"
+        + "tepc:label-hop/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label hop for the explicit route objects always
+      excluded by the path computation of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-hop;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:explicit-route-objects-always/"
+        + "tepc:route-object-include-exclude/tepc:type/tepc:label/"
+        + "tepc:label-hop/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label hop for the explicit route objects included
+      or excluded by the path computation of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-hop;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-in-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction/"
+        + "tepc:label-start/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label range start for the ingress segment
+      of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-start-end;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-in-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction/"
+        + "tepc:label-end/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label range end for the ingress segment
+      of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-start-end;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-in-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction/"
+        + "tepc:label-step/tepc:technology" {
+    description
+      "Augment TE label range step for the ingress segment
+      of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-step;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-out-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction/"
+        + "tepc:label-start/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label range start for the egress segment
+      of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-start-end;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-out-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction/"
+        + "tepc:label-end/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label range end for the egress segment
+      of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-start-end;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:path-request/tepc:path-out-segment/"
+        + "tepc:label-restrictions/tepc:label-restriction/"
+        + "tepc:label-step/tepc:technology" {
+    description
+      "Augment TE label range end for the egress segment
+      of the requested path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-step;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:input/te:path-compute-info/"
+        + "tepc:synchronization/tepc:exclude-objects/tepc:excludes/"
+        + "tepc:type/tepc:label/tepc:label-hop/"
+        + "tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label hop for the explicit route objects to always
+      exclude from synchronized path computation.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-hop;
+    }
+  }
+
+  augment "/te:tunnels-path-compute/te:output/"
+        + "te:path-compute-result/tepc:response/"
+        + "tepc:computed-paths-properties/"
+        + "tepc:computed-path-properties/tepc:path-properties/"
+        + "tepc:path-route-objects/tepc:path-route-object/"
+        + "tepc:type/tepc:label/"
+        + "tepc:label-hop/tepc:te-label/tepc:technology" {
+    description
+      "Augment TE label hop for the route object of the computed
+      path.";
+    case flexi-grid {
+      uses l0-types:flexi-grid-label-hop;
+    }
+  }
+}


### PR DESCRIPTION
Initial proposal for flexi-grid path computation YANG

Started from the RPC in https://datatracker.ietf.org/doc/draft-ietf-ccamp-flexigrid-media-channel-yang/04/ and add flexi-grid technology-specific augmentations for the te-label and label-ranges

Fix #4